### PR TITLE
Fix for null player exception

### DIFF
--- a/paper/src/main/java/com/biggestnerd/namecolors/NameColors.java
+++ b/paper/src/main/java/com/biggestnerd/namecolors/NameColors.java
@@ -8,7 +8,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import vg.civcraft.mc.civchat2.CivChat2;
 import vg.civcraft.mc.civmodcore.ACivMod;
 import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
@@ -45,7 +45,7 @@ public class NameColors extends ACivMod implements Listener {
 	}
 
 	@EventHandler
-	public void onPlayerLogin(PlayerLoginEvent event) {
+	public void onPlayerJoin(PlayerJoinEvent event) {
 		updatePlayerName(event.getPlayer(), setting.getValue(event.getPlayer()));
 	}
 


### PR DESCRIPTION
Fixes #7 

[PlayerLoginEvent](https://jd.papermc.io/paper/1.18/org/bukkit/event/player/PlayerLoginEvent.html) is fired when a player attempts to log in, but that attempt is not always successful (banned, not whitelisted, player clicks cancel, etc), which can lead to the player reference being null.

[PlayerJoinEvent](https://jd.papermc.io/paper/1.18/org/bukkit/event/player/PlayerJoinEvent.html) is fired when the player has joined the server, which should prevent #7 happening. (Technically, due to the 20 tick task delay, it probably could still happen if the player disconnects fast enough, but should be rare in practice).

Before change (error):
![image](https://user-images.githubusercontent.com/38970841/171100901-02f86dea-d07e-471b-a301-53063922c265.png)

After change (no error):
![image](https://user-images.githubusercontent.com/38970841/171100483-d5b90be7-a87e-47a6-acf4-ab91ca2667ce.png)
